### PR TITLE
Use ToStringHelper.add("field", field) instead of addValue(field)

### DIFF
--- a/src/com/seanlandsman/idea/plugins/GenerateToString.java
+++ b/src/com/seanlandsman/idea/plugins/GenerateToString.java
@@ -25,7 +25,11 @@ public class GenerateToString extends GuavaUtilityGeneration {
         builder.append("public String toString() { \n");
         builder.append("return ").append(COM_GOOGLE_COMMON_BASE_OBJECTS).append(".toStringHelper(this)\n");
         for (PsiField field : fields) {
-            builder.append(".addValue(").append(field.getName()).append(")\n");
+            builder.append(".add(\"")
+                    .append(field.getName())
+                    .append("\", ")
+                    .append(field.getName())
+                    .append(")\n");
         }
         builder.append(".toString();\n}");
         setNewMethod(psiClass, builder.toString(), "toString");


### PR DESCRIPTION
Adding names to values improves readability of toString output.

From ToStringHelper.addValue JavaDoc:

> Adds an unnamed value to the formatted output.
> It is strongly encouraged to use add(String, Object) instead and give value a readable name.
